### PR TITLE
Allow installation via ansible-galaxy requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@ Include the `aws-cloudwatch-logs` role in your playbook yml like this:
         - file: /var/log/my_cool_log
           format: "%b %d %H:%M:%S"
           group_name: my-cool-log
+          stream_name: "{{ ansible_hostname }}"
 
 ## Author
 Christian Willman <github@willman.io>
+
+## Changes
+Paul De Audney <pdeaudney@gmail.com>
+- Add ansible-galaxy meta.yml
+- Optionally configure `stream_name` or default to `{instance_id}` in the template
 
 ## License
 MIT

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,4 @@
 ---
-dependencies: []
-
 galaxy_info:
   author: Christian Willman
   description: An Ansible role for forwarding log files to CloudWatch.
@@ -11,7 +9,8 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
-galaxy_tags:
-  - cloudwatch
-  - aws
-  - logging
+  galaxy_tags:
+    - cloudwatch
+    - aws
+    - logging
+dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,17 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: Christian Willman
+  description: An Ansible role for forwarding log files to CloudWatch.
+  company: Christian Willman
+  license: MIT
+  min_ansible_version: 1.9
+  platforms:
+  - name: Ubuntu
+    versions:
+    - trusty
+galaxy_tags:
+  - cloudwatch
+  - aws
+  - logging

--- a/templates/awslogs.conf.j2
+++ b/templates/awslogs.conf.j2
@@ -121,5 +121,5 @@ state_file = /var/awslogs/state/agent-state
 datetime_format = {{ log.format }}
 file = {{ log.file }}
 log_group_name = {{ log.group_name }}
-log_stream_name = {instance_id}
+log_stream_name = {{ log.stream_name | default('{instance_id}') }}
 {% endfor %}


### PR DESCRIPTION
### Ansible Galaxy support

This change will allow installation via ansible-galaxy requirements files.

For example I am using this in my local ansible project to install the modified role.

```
- src: https://github.com/pdeaudney/ansible-aws-cloudwatch-logs
  version: master
  name: aws-cloudwatch-logs
```

Ref: https://galaxy.ansible.com/intro#download-advanced
### Override log stream name optionally

I can also override the stream_name for logs in Cloudwatch logs. Or not provide a stream_name and have the default behavior of using the `{instance_id}` setting.
