### PR TITLE
use long option names for increased readability

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,4 +21,4 @@
     url: https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
 
 - name: Install the AWS CloudWatch Logs daemon
-  shell: python /tmp/awslogs-agent-setup.py -n -r {{ ec2_region.stdout }} -c /tmp/awslogs.conf
+  shell: python /tmp/awslogs-agent-setup.py --non-interactive --region={{ ec2_region.stdout }} --configfile=/tmp/awslogs.conf


### PR DESCRIPTION
it is much more readable to always use long option names in a script since it will be read by human beings and help them understand, especially when they don't know what the options are. Short options are handy when you want to type commands as fast as possible, but in a script, readability comes first (and options get typed once and stay in a file), IMHO.
